### PR TITLE
Tests/comprehensive unit tests

### DIFF
--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -1,0 +1,5 @@
+version: 2
+
+ignore-paths:
+  - "**/*_test.go"
+  - "tests/**"

--- a/internal/api/response/response.go
+++ b/internal/api/response/response.go
@@ -15,7 +15,7 @@ type Response struct {
 func JSON(w http.ResponseWriter, status int, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(data)
+	_ = json.NewEncoder(w).Encode(data)
 }
 
 func Success(w http.ResponseWriter, data interface{}) {

--- a/internal/api/security_test.go
+++ b/internal/api/security_test.go
@@ -1,0 +1,253 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/smalex-z/gopher/internal/db"
+	"github.com/smalex-z/gopher/internal/service"
+)
+
+func initTestDB(t *testing.T) {
+	t.Helper()
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "_"))
+	if err := db.Initialize(dsn); err != nil {
+		t.Fatalf("initTestDB: %v", err)
+	}
+}
+
+// newTestRouter builds a minimal router wired to an in-memory DB and real auth service.
+func newTestRouter(t *testing.T) (http.Handler, *service.AuthService) {
+	t.Helper()
+	initTestDB(t)
+
+	authSvc := service.NewAuthService()
+	deploySvc := service.NewDeployService()
+	vpsSvc := service.NewVPSService(deploySvc)
+	machineSvc := service.NewMachineService(deploySvc, nil)
+	tunnelSvc := service.NewTunnelService(nil)
+	localSvc := service.NewLocalSetupService(deploySvc.Hub)
+	bootstrapSvc := service.NewBootstrapService(localSvc)
+	updateSvc := service.NewUpdateService()
+	secSvc := service.NewSecurityService()
+
+	router := NewRouter(vpsSvc, machineSvc, tunnelSvc, deploySvc, bootstrapSvc, authSvc, localSvc, updateSvc, secSvc)
+	return router, authSvc
+}
+
+// authenticatedCookie returns a valid session cookie for a freshly set-up auth service.
+func authenticatedCookie(t *testing.T, svc *service.AuthService) *http.Cookie {
+	t.Helper()
+	if err := svc.Setup("testpassword"); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	result, err := svc.Login("testpassword", "127.0.0.1")
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	return &http.Cookie{Name: "gopher_session", Value: result.Token}
+}
+
+// ---- Unauthenticated access -------------------------------------------------
+
+func TestUnauthenticated_MachinesReturns401(t *testing.T) {
+	router, _ := newTestRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/machines", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("GET /api/machines without auth = %d, want 401", w.Code)
+	}
+}
+
+func TestUnauthenticated_TunnelsReturns401(t *testing.T) {
+	router, _ := newTestRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/tunnels", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("GET /api/tunnels without auth = %d, want 401", w.Code)
+	}
+}
+
+func TestUnauthenticated_VPSReturns401(t *testing.T) {
+	router, _ := newTestRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/vps", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("GET /api/vps without auth = %d, want 401", w.Code)
+	}
+}
+
+func TestUnauthenticated_SecurityReturns401(t *testing.T) {
+	router, _ := newTestRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/security/logs", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("GET /api/security/logs without auth = %d, want 401", w.Code)
+	}
+}
+
+func TestUnauthenticated_UpdateReturns401(t *testing.T) {
+	router, _ := newTestRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/update/check", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("GET /api/update/check without auth = %d, want 401", w.Code)
+	}
+}
+
+func TestUnauthenticated_DebugReturns401(t *testing.T) {
+	router, _ := newTestRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/caddyfile", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("GET /api/debug/caddyfile without auth = %d, want 401", w.Code)
+	}
+}
+
+// ---- Public routes remain accessible ----------------------------------------
+
+func TestPublic_AuthStatusReachable(t *testing.T) {
+	router, _ := newTestRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/status", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code == http.StatusUnauthorized {
+		t.Error("GET /api/auth/status should be public (no auth required)")
+	}
+}
+
+func TestPublic_StatusReachable(t *testing.T) {
+	router, _ := newTestRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code == http.StatusUnauthorized {
+		t.Error("GET /api/status should be public")
+	}
+}
+
+func TestPublic_LocalStatusReachable(t *testing.T) {
+	router, _ := newTestRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/local/status", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code == http.StatusUnauthorized {
+		t.Error("GET /api/local/status should be public")
+	}
+}
+
+// ---- Invalid session token is rejected --------------------------------------
+
+func TestInvalidSession_Returns401(t *testing.T) {
+	router, _ := newTestRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/machines", nil)
+	req.AddCookie(&http.Cookie{Name: "gopher_session", Value: "fake-invalid-token"})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("fake session token = %d, want 401", w.Code)
+	}
+}
+
+// ---- Authenticated access works --------------------------------------------
+
+func TestAuthenticated_MachinesReturns200(t *testing.T) {
+	router, authSvc := newTestRouter(t)
+	cookie := authenticatedCookie(t, authSvc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/machines", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("authenticated GET /api/machines = %d, want 200", w.Code)
+	}
+}
+
+func TestAuthenticated_TunnelsReturns200(t *testing.T) {
+	router, authSvc := newTestRouter(t)
+	cookie := authenticatedCookie(t, authSvc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tunnels", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("authenticated GET /api/tunnels = %d, want 200", w.Code)
+	}
+}
+
+// ---- CORS headers -----------------------------------------------------------
+
+func TestCORS_OptionsPreflightReturns200(t *testing.T) {
+	router, _ := newTestRouter(t)
+	req := httptest.NewRequest(http.MethodOptions, "/api/machines", nil)
+	req.Header.Set("Origin", "http://localhost:5173")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK && w.Code != http.StatusNoContent {
+		t.Errorf("OPTIONS preflight = %d, want 200/204", w.Code)
+	}
+}
+
+func TestCORS_AllowedOriginHeader(t *testing.T) {
+	router, _ := newTestRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	req.Header.Set("Origin", "http://localhost:5173")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	// With AllowedOrigins: ["*"], the header should be present
+	if w.Header().Get("Access-Control-Allow-Origin") == "" {
+		t.Error("expected Access-Control-Allow-Origin header in response")
+	}
+}
+
+// ---- Response format --------------------------------------------------------
+
+func TestResponse_UnauthorizedIsJSON(t *testing.T) {
+	router, _ := newTestRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/machines", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	ct := w.Header().Get("Content-Type")
+	if !strings.Contains(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "unauthorized") {
+		t.Errorf("body = %q, expected 'unauthorized' message", body)
+	}
+}
+
+// ---- Logout invalidates session --------------------------------------------
+
+func TestLogout_InvalidatesSession(t *testing.T) {
+	router, authSvc := newTestRouter(t)
+	cookie := authenticatedCookie(t, authSvc)
+
+	// Logout
+	logoutReq := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
+	logoutReq.AddCookie(cookie)
+	lw := httptest.NewRecorder()
+	router.ServeHTTP(lw, logoutReq)
+
+	// Now try to use the same token
+	req := httptest.NewRequest(http.MethodGet, "/api/machines", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("after logout, session should be invalid: got %d", w.Code)
+	}
+}

--- a/internal/config/bench_test.go
+++ b/internal/config/bench_test.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/smalex-z/gopher/internal/db"
+)
+
+func BenchmarkGenerateRatholeServerConfig_10(b *testing.B) {
+	benchmarkGenerate(b, 5, 5)
+}
+
+func BenchmarkGenerateRatholeServerConfig_100(b *testing.B) {
+	benchmarkGenerate(b, 50, 50)
+}
+
+func BenchmarkGenerateRatholeServerConfig_200(b *testing.B) {
+	benchmarkGenerate(b, 100, 100)
+}
+
+func benchmarkGenerate(b *testing.B, nMachines, nTunnels int) {
+	b.Helper()
+	machines := make([]db.Machine, nMachines)
+	for i := range machines {
+		machines[i] = db.Machine{
+			ID:              fmt.Sprintf("m%d", i),
+			TunnelPort:      2000 + i,
+			RatholeSSHToken: fmt.Sprintf("token-m%d", i),
+		}
+	}
+	tunnels := make([]db.Tunnel, nTunnels)
+	for i := range tunnels {
+		tunnels[i] = db.Tunnel{
+			ID:           fmt.Sprintf("t%d", i),
+			RatholePort:  3000 + i,
+			RatholeToken: fmt.Sprintf("token-t%d", i),
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		GenerateRatholeServerConfig(machines, tunnels)
+	}
+}
+
+func BenchmarkParseRatholeConfig_100Entries(b *testing.B) {
+	machines := make([]db.Machine, 50)
+	tunnels := make([]db.Tunnel, 50)
+	for i := range machines {
+		machines[i] = db.Machine{ID: fmt.Sprintf("m%d", i), TunnelPort: 2000 + i, RatholeSSHToken: fmt.Sprintf("tok%d", i)}
+	}
+	for i := range tunnels {
+		tunnels[i] = db.Tunnel{ID: fmt.Sprintf("t%d", i), RatholePort: 3000 + i, RatholeToken: fmt.Sprintf("tok%d", i)}
+	}
+	cfg := GenerateRatholeServerConfig(machines, tunnels)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		parseRatholeConfig(cfg)
+	}
+}
+
+func BenchmarkValidateSubdomain(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = ValidateSubdomain("my-app-subdomain")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,482 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/smalex-z/gopher/internal/db"
+)
+
+// ---- ValidateSubdomain ------------------------------------------------------
+
+func TestValidateSubdomain(t *testing.T) {
+	valid := []string{
+		"app", "my-app", "myapp123", "a1b2c3",
+		"web", "api-v2", "x",
+	}
+	for _, s := range valid {
+		if err := ValidateSubdomain(s); err != nil {
+			t.Errorf("ValidateSubdomain(%q) unexpected error: %v", s, err)
+		}
+	}
+
+	invalid := []string{
+		"", "-app", "app-", "My-App", "app.sub",
+		"app_name", "APP", "has space",
+	}
+	for _, s := range invalid {
+		if err := ValidateSubdomain(s); err == nil {
+			t.Errorf("ValidateSubdomain(%q) expected error, got nil", s)
+		}
+	}
+}
+
+// ---- ValidatePort -----------------------------------------------------------
+
+func TestValidatePort(t *testing.T) {
+	validPorts := []int{1024, 8080, 65535, 3000, 9000}
+	for _, p := range validPorts {
+		if err := ValidatePort(p); err != nil {
+			t.Errorf("ValidatePort(%d) unexpected error: %v", p, err)
+		}
+	}
+
+	invalidPorts := []int{0, 22, 80, 443, 1023, 65536, -1}
+	for _, p := range invalidPorts {
+		if err := ValidatePort(p); err == nil {
+			t.Errorf("ValidatePort(%d) expected error, got nil", p)
+		}
+	}
+}
+
+// ---- GenerateRatholeServerConfig --------------------------------------------
+
+func TestGenerateRatholeServerConfig_Empty(t *testing.T) {
+	out := GenerateRatholeServerConfig(nil, nil)
+	if !strings.Contains(out, "[server]") {
+		t.Error("missing [server] section")
+	}
+	if !strings.Contains(out, "bind_addr = \"0.0.0.0:2333\"") {
+		t.Error("missing bind_addr")
+	}
+	// Placeholder added when no entries
+	if !strings.Contains(out, "[server.services.placeholder]") {
+		t.Error("expected placeholder when no tunnels or machines")
+	}
+}
+
+func TestGenerateRatholeServerConfig_WithTunnel(t *testing.T) {
+	tunnels := []db.Tunnel{
+		{ID: "t1", RatholePort: 8080, RatholeToken: "tok1"},
+	}
+	out := GenerateRatholeServerConfig(nil, tunnels)
+
+	if !strings.Contains(out, "# gopher-tunnel-start: t1") {
+		t.Error("missing tunnel start marker")
+	}
+	if !strings.Contains(out, "# gopher-tunnel-end: t1") {
+		t.Error("missing tunnel end marker")
+	}
+	if !strings.Contains(out, `token = "tok1"`) {
+		t.Error("missing token")
+	}
+	if !strings.Contains(out, "bind_addr = \"0.0.0.0:8080\"") {
+		t.Error("missing bind_addr for public tunnel")
+	}
+}
+
+func TestGenerateRatholeServerConfig_PrivateTunnel(t *testing.T) {
+	tunnels := []db.Tunnel{
+		{ID: "t1", RatholePort: 9000, RatholeToken: "tok", Private: true},
+	}
+	out := GenerateRatholeServerConfig(nil, tunnels)
+	if !strings.Contains(out, "bind_addr = \"127.0.0.1:9000\"") {
+		t.Errorf("private tunnel should bind 127.0.0.1, got:\n%s", out)
+	}
+}
+
+func TestGenerateRatholeServerConfig_UDPTunnel(t *testing.T) {
+	tunnels := []db.Tunnel{
+		{ID: "udp1", RatholePort: 5000, RatholeToken: "tok", Transport: "udp"},
+	}
+	out := GenerateRatholeServerConfig(nil, tunnels)
+	if !strings.Contains(out, `type = "udp"`) {
+		t.Error("UDP tunnel should include type = \"udp\"")
+	}
+}
+
+func TestGenerateRatholeServerConfig_WithMachine(t *testing.T) {
+	machines := []db.Machine{
+		{ID: "m1", TunnelPort: 2222, RatholeSSHToken: "ssh-tok"},
+	}
+	out := GenerateRatholeServerConfig(machines, nil)
+
+	if !strings.Contains(out, "# gopher-machine-start: m1") {
+		t.Error("missing machine start marker")
+	}
+	if !strings.Contains(out, `token = "ssh-tok"`) {
+		t.Error("missing machine token")
+	}
+	if !strings.Contains(out, "bind_addr = \"127.0.0.1:2222\"") {
+		t.Error("machine should default to private (127.0.0.1) when PublicSSH=false")
+	}
+}
+
+func TestGenerateRatholeServerConfig_PublicSSHMachine(t *testing.T) {
+	machines := []db.Machine{
+		{ID: "m1", TunnelPort: 2222, RatholeSSHToken: "ssh-tok", PublicSSH: true},
+	}
+	out := GenerateRatholeServerConfig(machines, nil)
+	if !strings.Contains(out, "bind_addr = \"0.0.0.0:2222\"") {
+		t.Errorf("public SSH machine should bind 0.0.0.0, got:\n%s", out)
+	}
+}
+
+func TestGenerateRatholeServerConfig_SkipsMachineWithoutToken(t *testing.T) {
+	machines := []db.Machine{
+		{ID: "m-no-token", TunnelPort: 2222, RatholeSSHToken: ""},
+		{ID: "m-no-port", TunnelPort: 0, RatholeSSHToken: "tok"},
+	}
+	out := GenerateRatholeServerConfig(machines, nil)
+	if strings.Contains(out, "m-no-token") || strings.Contains(out, "m-no-port") {
+		t.Error("machines without token or port should be skipped")
+	}
+}
+
+func TestGenerateRatholeServerConfig_TokenFallsBackToID(t *testing.T) {
+	tunnels := []db.Tunnel{
+		{ID: "t-legacy", RatholePort: 7000, RatholeToken: ""},
+	}
+	out := GenerateRatholeServerConfig(nil, tunnels)
+	if !strings.Contains(out, `token = "t-legacy"`) {
+		t.Error("tunnel with empty RatholeToken should fall back to ID as token")
+	}
+}
+
+func TestGenerateRatholeServerConfig_NoPlaceholderWhenHasMachines(t *testing.T) {
+	machines := []db.Machine{
+		{ID: "m1", TunnelPort: 2222, RatholeSSHToken: "tok"},
+	}
+	out := GenerateRatholeServerConfig(machines, nil)
+	if strings.Contains(out, "placeholder") {
+		t.Error("should not include placeholder when machines are present")
+	}
+}
+
+// ---- GenerateMachineSSHClientConfig -----------------------------------------
+
+func TestGenerateMachineSSHClientConfig(t *testing.T) {
+	m := &db.Machine{ID: "m1", RatholeSSHToken: "my-token"}
+	out := GenerateMachineSSHClientConfig("vps.example.com", m)
+
+	if !strings.Contains(out, `remote_addr = "vps.example.com:2333"`) {
+		t.Error("missing remote_addr")
+	}
+	if !strings.Contains(out, "# gopher-machine-start: m1") {
+		t.Error("missing machine start marker")
+	}
+	if !strings.Contains(out, `token = "my-token"`) {
+		t.Error("missing token")
+	}
+	if !strings.Contains(out, `local_addr = "0.0.0.0:22"`) {
+		t.Error("missing local_addr for SSH")
+	}
+}
+
+// ---- GenerateClientConfig ---------------------------------------------------
+
+func TestGenerateClientConfig(t *testing.T) {
+	tunnels := []db.Tunnel{
+		{ID: "t1", RatholeToken: "tok1", LocalPort: 8080},
+		{ID: "t2", RatholeToken: "tok2", LocalPort: 9090},
+	}
+	out, err := GenerateClientConfig("vps.example.com", tunnels)
+	if err != nil {
+		t.Fatalf("GenerateClientConfig: %v", err)
+	}
+
+	if !strings.Contains(out, `remote_addr = "vps.example.com:2333"`) {
+		t.Error("missing remote_addr")
+	}
+	if !strings.Contains(out, "tunnel-t1") {
+		t.Error("missing tunnel t1")
+	}
+	if !strings.Contains(out, "tunnel-t2") {
+		t.Error("missing tunnel t2")
+	}
+	if !strings.Contains(out, "127.0.0.1:8080") {
+		t.Error("missing local_addr for t1")
+	}
+}
+
+func TestGenerateClientConfig_Empty(t *testing.T) {
+	out, err := GenerateClientConfig("vps.example.com", nil)
+	if err != nil {
+		t.Fatalf("GenerateClientConfig (empty): %v", err)
+	}
+	if !strings.Contains(out, `remote_addr = "vps.example.com:2333"`) {
+		t.Error("missing remote_addr for empty config")
+	}
+}
+
+// ---- extractPortFromBindAddr ------------------------------------------------
+
+func TestExtractPortFromBindAddr(t *testing.T) {
+	tests := []struct {
+		addr string
+		want int
+	}{
+		{"0.0.0.0:8080", 8080},
+		{"127.0.0.1:2222", 2222},
+		{"0.0.0.0:65535", 65535},
+		{"", 0},
+		{"noport", 0},
+		{"host:notanumber", 0},
+		{"a:b:c", 0},
+	}
+	for _, tt := range tests {
+		got := extractPortFromBindAddr(tt.addr)
+		if got != tt.want {
+			t.Errorf("extractPortFromBindAddr(%q) = %d, want %d", tt.addr, got, tt.want)
+		}
+	}
+}
+
+// ---- parseRatholeConfig -----------------------------------------------------
+
+func TestParseRatholeConfig_BasicTunnel(t *testing.T) {
+	cfg := `
+[server]
+bind_addr = "0.0.0.0:2333"
+
+# gopher-tunnel-start: t1
+[server.services.tunnel-t1]
+token = "tok1"
+bind_addr = "0.0.0.0:8080"
+# gopher-tunnel-end: t1
+`
+	result := parseRatholeConfig(cfg)
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	entry, ok := result.Tunnels["t1"]
+	if !ok {
+		t.Fatal("expected tunnel t1 in result")
+	}
+	if entry.Token != "tok1" {
+		t.Errorf("Token = %q, want %q", entry.Token, "tok1")
+	}
+	if entry.BindAddr != "0.0.0.0:8080" {
+		t.Errorf("BindAddr = %q, want %q", entry.BindAddr, "0.0.0.0:8080")
+	}
+}
+
+func TestParseRatholeConfig_BasicMachine(t *testing.T) {
+	cfg := `
+# gopher-machine-start: m1
+[server.services.machine-m1-ssh]
+token = "ssh-tok"
+bind_addr = "127.0.0.1:2222"
+# gopher-machine-end: m1
+`
+	result := parseRatholeConfig(cfg)
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	entry, ok := result.Machines["m1"]
+	if !ok {
+		t.Fatal("expected machine m1")
+	}
+	if entry.Token != "ssh-tok" {
+		t.Errorf("Token = %q, want %q", entry.Token, "ssh-tok")
+	}
+}
+
+func TestParseRatholeConfig_DuplicateID(t *testing.T) {
+	cfg := `
+# gopher-tunnel-start: t1
+token = "tok1"
+bind_addr = "0.0.0.0:8080"
+# gopher-tunnel-end: t1
+
+# gopher-tunnel-start: t1
+token = "tok2"
+bind_addr = "0.0.0.0:8081"
+# gopher-tunnel-end: t1
+`
+	result := parseRatholeConfig(cfg)
+	if len(result.DuplicateIDs) == 0 {
+		t.Error("expected duplicate ID to be detected")
+	}
+}
+
+func TestParseRatholeConfig_UnclosedMarker(t *testing.T) {
+	cfg := `
+# gopher-tunnel-start: t1
+token = "tok"
+bind_addr = "0.0.0.0:8080"
+`
+	result := parseRatholeConfig(cfg)
+	if len(result.Errors) == 0 {
+		t.Error("expected error for unclosed marker")
+	}
+}
+
+func TestParseRatholeConfig_OrphanedEndMarker(t *testing.T) {
+	cfg := `
+# gopher-tunnel-end: t1
+`
+	result := parseRatholeConfig(cfg)
+	if len(result.Errors) == 0 {
+		t.Error("expected error for orphaned end marker")
+	}
+}
+
+func TestParseRatholeConfig_MismatchedMarkers(t *testing.T) {
+	cfg := `
+# gopher-tunnel-start: t1
+token = "tok"
+# gopher-tunnel-end: t2
+`
+	result := parseRatholeConfig(cfg)
+	if len(result.Errors) == 0 {
+		t.Error("expected error for mismatched start/end IDs")
+	}
+}
+
+// ---- ValidateRatholeConfig --------------------------------------------------
+
+func TestValidateRatholeConfig_MatchesDB(t *testing.T) {
+	machines := []db.Machine{
+		{ID: "m1", TunnelPort: 2222, RatholeSSHToken: "ssh-tok"},
+	}
+	tunnels := []db.Tunnel{
+		{ID: "t1", RatholePort: 8080, RatholeToken: "tok1"},
+	}
+	cfg := GenerateRatholeServerConfig(machines, tunnels)
+
+	result := ValidateRatholeConfig(cfg, machines, tunnels)
+	if !result.Valid {
+		t.Errorf("expected valid config, errors: %v", result.Errors)
+	}
+}
+
+func TestValidateRatholeConfig_OrphanedEntry(t *testing.T) {
+	cfg := `
+[server]
+bind_addr = "0.0.0.0:2333"
+# gopher-tunnel-start: orphan
+[server.services.tunnel-orphan]
+token = "tok"
+bind_addr = "0.0.0.0:9999"
+# gopher-tunnel-end: orphan
+`
+	result := ValidateRatholeConfig(cfg, nil, nil)
+	if result.Valid {
+		t.Error("expected invalid — config has tunnel not in DB")
+	}
+	if len(result.Orphans) == 0 {
+		t.Error("expected orphan to be reported")
+	}
+}
+
+func TestValidateRatholeConfig_MissingEntry(t *testing.T) {
+	tunnels := []db.Tunnel{
+		{ID: "t1", RatholePort: 8080, RatholeToken: "tok1"},
+	}
+	result := ValidateRatholeConfig("[server]\nbind_addr = \"0.0.0.0:2333\"\n", nil, tunnels)
+	if result.Valid {
+		t.Error("expected invalid — DB has tunnel not in config")
+	}
+	if len(result.Missing) == 0 {
+		t.Error("expected missing entry to be reported")
+	}
+}
+
+func TestValidateRatholeConfig_TokenMismatch(t *testing.T) {
+	tunnels := []db.Tunnel{
+		{ID: "t1", RatholePort: 8080, RatholeToken: "correct-token"},
+	}
+	cfg := `
+[server]
+bind_addr = "0.0.0.0:2333"
+# gopher-tunnel-start: t1
+[server.services.tunnel-t1]
+token = "wrong-token"
+bind_addr = "0.0.0.0:8080"
+# gopher-tunnel-end: t1
+`
+	result := ValidateRatholeConfig(cfg, nil, tunnels)
+	if result.Valid {
+		t.Error("expected invalid due to token mismatch")
+	}
+	found := false
+	for _, e := range result.Errors {
+		if strings.Contains(e, "Token mismatch") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected Token mismatch error, got: %v", result.Errors)
+	}
+}
+
+func TestValidateRatholeConfig_PortMismatch(t *testing.T) {
+	tunnels := []db.Tunnel{
+		{ID: "t1", RatholePort: 8080, RatholeToken: "tok"},
+	}
+	cfg := `
+[server]
+bind_addr = "0.0.0.0:2333"
+# gopher-tunnel-start: t1
+[server.services.tunnel-t1]
+token = "tok"
+bind_addr = "0.0.0.0:9999"
+# gopher-tunnel-end: t1
+`
+	result := ValidateRatholeConfig(cfg, nil, tunnels)
+	if result.Valid {
+		t.Error("expected invalid due to port mismatch")
+	}
+}
+
+func TestValidateRatholeConfig_SkipsMachineWithoutToken(t *testing.T) {
+	// Machines without SSH token should not be required in config
+	machines := []db.Machine{
+		{ID: "m-no-tok", TunnelPort: 2222, RatholeSSHToken: ""},
+	}
+	result := ValidateRatholeConfig("[server]\nbind_addr = \"0.0.0.0:2333\"\n", machines, nil)
+	if !result.Valid {
+		t.Errorf("machine without token should be excluded from validation, errors: %v", result.Errors)
+	}
+}
+
+// ---- Roundtrip: generate then validate --------------------------------------
+
+func TestRoundtrip_GenerateAndValidate(t *testing.T) {
+	now := time.Now()
+	machines := []db.Machine{
+		{ID: "m1", TunnelPort: 2222, RatholeSSHToken: "tok-m1"},
+		{ID: "m2", TunnelPort: 2223, RatholeSSHToken: "tok-m2", PublicSSH: true},
+	}
+	tunnels := []db.Tunnel{
+		{ID: "t1", RatholePort: 8001, RatholeToken: "tok-t1", CreatedAt: now, UpdatedAt: now},
+		{ID: "t2", RatholePort: 8002, RatholeToken: "tok-t2", Private: true, CreatedAt: now, UpdatedAt: now},
+		{ID: "t3", RatholePort: 8003, RatholeToken: "tok-t3", Transport: "udp", CreatedAt: now, UpdatedAt: now},
+	}
+
+	cfg := GenerateRatholeServerConfig(machines, tunnels)
+	result := ValidateRatholeConfig(cfg, machines, tunnels)
+
+	if !result.Valid {
+		t.Errorf("roundtrip validation failed: %v", result.Errors)
+	}
+	if len(result.Orphans) > 0 {
+		t.Errorf("unexpected orphans: %v", result.Orphans)
+	}
+	if len(result.Missing) > 0 {
+		t.Errorf("unexpected missing: %v", result.Missing)
+	}
+}

--- a/internal/config/rathole.go
+++ b/internal/config/rathole.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
-	"net"
 	"strconv"
 	"strings"
 	"text/template"
@@ -136,22 +135,6 @@ func extractPortFromBindAddr(bindAddr string) int {
 		return 0
 	}
 	port, err := strconv.Atoi(strings.TrimSpace(parts[1]))
-	if err != nil {
-		return 0
-	}
-	return port
-}
-
-// extractPortFromAddr extracts the port number from "host:PORT" format
-func extractPortFromAddr(addr string) int {
-	if addr == "" {
-		return 0
-	}
-	_, portStr, err := net.SplitHostPort(addr)
-	if err != nil {
-		return 0
-	}
-	port, err := strconv.Atoi(portStr)
 	if err != nil {
 		return 0
 	}

--- a/internal/db/bench_test.go
+++ b/internal/db/bench_test.go
@@ -1,0 +1,56 @@
+package db
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func BenchmarkNextRatholePort_Empty(b *testing.B) {
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.ReplaceAll("BenchmarkNextRatholePort_Empty", "/", "_"))
+	if err := Initialize(dsn); err != nil {
+		b.Fatalf("Initialize: %v", err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = NextRatholePort()
+	}
+}
+
+func BenchmarkNextRatholePort_100Entries(b *testing.B) {
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.ReplaceAll("BenchmarkNextRatholePort_100Entries", "/", "_"))
+	if err := Initialize(dsn); err != nil {
+		b.Fatalf("Initialize: %v", err)
+	}
+	// Pre-populate 100 tunnels and machines filling ports 1024..1123
+	_ = CreateMachine(&Machine{ID: "bm0", TunnelPort: 0})
+	for i := 0; i < 50; i++ {
+		_ = CreateMachine(&Machine{ID: fmt.Sprintf("bm%d", i+1), TunnelPort: 1024 + i})
+	}
+	for i := 0; i < 50; i++ {
+		_ = CreateTunnel(&Tunnel{ID: fmt.Sprintf("bt%d", i), MachineID: "bm0", RatholePort: 1074 + i})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = NextRatholePort()
+	}
+}
+
+func BenchmarkCheckSubdomainExists(b *testing.B) {
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.ReplaceAll("BenchmarkCheckSubdomainExists", "/", "_"))
+	if err := Initialize(dsn); err != nil {
+		b.Fatalf("Initialize: %v", err)
+	}
+	_ = CreateMachine(&Machine{ID: "bm0"})
+	for i := 0; i < 50; i++ {
+		_ = CreateTunnel(&Tunnel{
+			ID:        fmt.Sprintf("bt%d", i),
+			MachineID: "bm0",
+			Subdomain: fmt.Sprintf("sub%d", i),
+		})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = CheckSubdomainExists("sub25")
+	}
+}

--- a/internal/db/repository_test.go
+++ b/internal/db/repository_test.go
@@ -1,0 +1,447 @@
+package db
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func initTestDB(t *testing.T) {
+	t.Helper()
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "_"))
+	if err := Initialize(dsn); err != nil {
+		t.Fatalf("failed to init test db: %v", err)
+	}
+}
+
+// seedMachine creates a minimal machine for tests that need a valid FK target.
+func seedMachine(t *testing.T, id string) {
+	t.Helper()
+	_ = CreateMachine(&Machine{ID: id, Name: id, Status: "active"})
+}
+
+// seedTunnel creates a tunnel under machineID with given rathole port.
+func seedTunnel(t *testing.T, id, machineID string, port int) {
+	t.Helper()
+	if err := CreateTunnel(&Tunnel{ID: id, MachineID: machineID, RatholePort: port}); err != nil {
+		t.Fatalf("seedTunnel %s: %v", id, err)
+	}
+}
+
+// ---- Machine CRUD -----------------------------------------------------------
+
+func TestMachine_CreateAndGet(t *testing.T) {
+	initTestDB(t)
+	m := &Machine{
+		ID:     "m1",
+		Name:   "test-machine",
+		Status: "connected",
+	}
+	if err := CreateMachine(m); err != nil {
+		t.Fatalf("CreateMachine: %v", err)
+	}
+	got, err := GetMachine("m1")
+	if err != nil {
+		t.Fatalf("GetMachine: %v", err)
+	}
+	if got.Name != "test-machine" {
+		t.Errorf("Name = %q, want %q", got.Name, "test-machine")
+	}
+}
+
+func TestMachine_GetNotFound(t *testing.T) {
+	initTestDB(t)
+	_, err := GetMachine("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing machine, got nil")
+	}
+}
+
+func TestMachine_Update(t *testing.T) {
+	initTestDB(t)
+	m := &Machine{ID: "m1", Name: "old", Status: "active"}
+	if err := CreateMachine(m); err != nil {
+		t.Fatalf("CreateMachine: %v", err)
+	}
+	m.Name = "new"
+	if err := UpdateMachine(m); err != nil {
+		t.Fatalf("UpdateMachine: %v", err)
+	}
+	got, _ := GetMachine("m1")
+	if got.Name != "new" {
+		t.Errorf("Name = %q, want %q", got.Name, "new")
+	}
+}
+
+func TestMachine_Delete(t *testing.T) {
+	initTestDB(t)
+	m := &Machine{ID: "m1", Name: "del", Status: "active"}
+	_ = CreateMachine(m)
+	if err := DeleteMachine("m1"); err != nil {
+		t.Fatalf("DeleteMachine: %v", err)
+	}
+	_, err := GetMachine("m1")
+	if err == nil {
+		t.Fatal("expected error after delete, got nil")
+	}
+}
+
+func TestGetMachines_ReturnsAll(t *testing.T) {
+	initTestDB(t)
+	for i := 0; i < 3; i++ {
+		_ = CreateMachine(&Machine{ID: fmt.Sprintf("m%d", i), Name: fmt.Sprintf("m%d", i), Status: "active"})
+	}
+	machines, err := GetMachines()
+	if err != nil {
+		t.Fatalf("GetMachines: %v", err)
+	}
+	if len(machines) != 3 {
+		t.Errorf("len = %d, want 3", len(machines))
+	}
+}
+
+// ---- Tunnel CRUD ------------------------------------------------------------
+
+func TestTunnel_CreateAndGet(t *testing.T) {
+	initTestDB(t)
+	seedMachine(t, "m1")
+	tun := &Tunnel{
+		ID:          "t1",
+		MachineID:   "m1",
+		Name:        "web",
+		Subdomain:   "web",
+		RatholePort: 8080,
+	}
+	if err := CreateTunnel(tun); err != nil {
+		t.Fatalf("CreateTunnel: %v", err)
+	}
+	got, err := GetTunnel("t1")
+	if err != nil {
+		t.Fatalf("GetTunnel: %v", err)
+	}
+	if got.Name != "web" {
+		t.Errorf("Name = %q, want %q", got.Name, "web")
+	}
+}
+
+func TestTunnel_GetNotFound(t *testing.T) {
+	initTestDB(t)
+	_, err := GetTunnel("nope")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestTunnel_Delete(t *testing.T) {
+	initTestDB(t)
+	seedMachine(t, "m1")
+	_ = CreateTunnel(&Tunnel{ID: "t1", MachineID: "m1", Name: "del", RatholePort: 9000})
+	if err := DeleteTunnel("t1"); err != nil {
+		t.Fatalf("DeleteTunnel: %v", err)
+	}
+	_, err := GetTunnel("t1")
+	if err == nil {
+		t.Fatal("expected error after delete, got nil")
+	}
+}
+
+func TestGetTunnelsByMachine(t *testing.T) {
+	initTestDB(t)
+	seedMachine(t, "m1")
+	seedMachine(t, "m2")
+	_ = CreateTunnel(&Tunnel{ID: "t1", MachineID: "m1", RatholePort: 8001})
+	_ = CreateTunnel(&Tunnel{ID: "t2", MachineID: "m1", RatholePort: 8002})
+	_ = CreateTunnel(&Tunnel{ID: "t3", MachineID: "m2", RatholePort: 8003})
+	tunnels, err := GetTunnelsByMachine("m1")
+	if err != nil {
+		t.Fatalf("GetTunnelsByMachine: %v", err)
+	}
+	if len(tunnels) != 2 {
+		t.Errorf("len = %d, want 2", len(tunnels))
+	}
+}
+
+// ---- Port assignment --------------------------------------------------------
+
+func TestNextRatholePort_Empty(t *testing.T) {
+	initTestDB(t)
+	port, err := NextRatholePort()
+	if err != nil {
+		t.Fatalf("NextRatholePort: %v", err)
+	}
+	if port != 1024 {
+		t.Errorf("port = %d, want 1024", port)
+	}
+}
+
+func TestNextRatholePort_SkipsUsed(t *testing.T) {
+	initTestDB(t)
+	seedMachine(t, "m1")
+	// Use 1024 and 1025 in service tunnels
+	seedTunnel(t, "t1", "m1", 1024)
+	seedTunnel(t, "t2", "m1", 1025)
+	port, err := NextRatholePort()
+	if err != nil {
+		t.Fatalf("NextRatholePort: %v", err)
+	}
+	if port != 1026 {
+		t.Errorf("port = %d, want 1026", port)
+	}
+}
+
+func TestNextRatholePort_SkipsMachinePorts(t *testing.T) {
+	initTestDB(t)
+	// Machine SSH tunnel occupies 1024
+	_ = CreateMachine(&Machine{ID: "m1", TunnelPort: 1024})
+	port, err := NextRatholePort()
+	if err != nil {
+		t.Fatalf("NextRatholePort: %v", err)
+	}
+	if port != 1025 {
+		t.Errorf("port = %d, want 1025 (skipping machine port 1024), got %d", port, port)
+	}
+}
+
+func TestNextRatholePort_FindsGap(t *testing.T) {
+	initTestDB(t)
+	seedMachine(t, "m1")
+	// 1024, 1025 used; 1026 free; 1027 used
+	seedTunnel(t, "t1", "m1", 1024)
+	seedTunnel(t, "t2", "m1", 1025)
+	seedTunnel(t, "t3", "m1", 1027)
+	port, err := NextRatholePort()
+	if err != nil {
+		t.Fatalf("NextRatholePort: %v", err)
+	}
+	if port != 1026 {
+		t.Errorf("port = %d, want 1026 (first gap)", port)
+	}
+}
+
+func TestNextSSHTunnelPort_SharesPortSpace(t *testing.T) {
+	initTestDB(t)
+	seedMachine(t, "m1")
+	seedTunnel(t, "t1", "m1", 1024)
+	port, err := NextSSHTunnelPort()
+	if err != nil {
+		t.Fatalf("NextSSHTunnelPort: %v", err)
+	}
+	if port != 1025 {
+		t.Errorf("port = %d, want 1025", port)
+	}
+}
+
+// ---- Subdomain + port conflict checks ---------------------------------------
+
+func TestCheckSubdomainExists(t *testing.T) {
+	initTestDB(t)
+	seedMachine(t, "m1")
+	_ = CreateTunnel(&Tunnel{ID: "t1", MachineID: "m1", Subdomain: "myapp", RatholePort: 8080})
+
+	exists, err := CheckSubdomainExists("myapp")
+	if err != nil {
+		t.Fatalf("CheckSubdomainExists: %v", err)
+	}
+	if !exists {
+		t.Error("expected subdomain 'myapp' to exist")
+	}
+
+	exists, err = CheckSubdomainExists("other")
+	if err != nil {
+		t.Fatalf("CheckSubdomainExists: %v", err)
+	}
+	if exists {
+		t.Error("expected subdomain 'other' to not exist")
+	}
+}
+
+func TestCheckRatholePortExists_TunnelPort(t *testing.T) {
+	initTestDB(t)
+	seedMachine(t, "m1")
+	_ = CreateTunnel(&Tunnel{ID: "t1", MachineID: "m1", RatholePort: 9999})
+
+	exists, err := CheckRatholePortExists(9999)
+	if err != nil {
+		t.Fatalf("CheckRatholePortExists: %v", err)
+	}
+	if !exists {
+		t.Error("expected port 9999 to exist in tunnels")
+	}
+
+	exists, err = CheckRatholePortExists(9998)
+	if err != nil {
+		t.Fatalf("CheckRatholePortExists: %v", err)
+	}
+	if exists {
+		t.Error("expected port 9998 to not exist")
+	}
+}
+
+func TestCheckRatholePortExists_MachinePort(t *testing.T) {
+	initTestDB(t)
+	_ = CreateMachine(&Machine{ID: "m1", TunnelPort: 2222})
+
+	exists, err := CheckRatholePortExists(2222)
+	if err != nil {
+		t.Fatalf("CheckRatholePortExists (machine): %v", err)
+	}
+	if !exists {
+		t.Error("expected port 2222 to exist via machine tunnel_port")
+	}
+}
+
+// ---- AppSettings ------------------------------------------------------------
+
+func TestSettings_DefaultWhenAbsent(t *testing.T) {
+	initTestDB(t)
+	s, err := GetSettings()
+	if err != nil {
+		t.Fatalf("GetSettings: %v", err)
+	}
+	if s.IsSetup {
+		t.Error("expected IsSetup=false for fresh DB")
+	}
+}
+
+func TestSettings_SaveAndReload(t *testing.T) {
+	initTestDB(t)
+	s := &AppSettings{
+		ID:             "singleton",
+		IsSetup:        true,
+		Domain:         "example.com",
+		UpdateChannel:  "beta",
+		LocalSetupDone: true,
+	}
+	if err := SaveSettings(s); err != nil {
+		t.Fatalf("SaveSettings: %v", err)
+	}
+	got, err := GetSettings()
+	if err != nil {
+		t.Fatalf("GetSettings: %v", err)
+	}
+	if !got.IsSetup {
+		t.Error("IsSetup should be true")
+	}
+	if got.Domain != "example.com" {
+		t.Errorf("Domain = %q, want %q", got.Domain, "example.com")
+	}
+	if got.UpdateChannel != "beta" {
+		t.Errorf("UpdateChannel = %q, want %q", got.UpdateChannel, "beta")
+	}
+}
+
+func TestSettings_Update(t *testing.T) {
+	initTestDB(t)
+	_ = SaveSettings(&AppSettings{ID: "singleton", Domain: "old.com"})
+	_ = SaveSettings(&AppSettings{ID: "singleton", Domain: "new.com"})
+	got, _ := GetSettings()
+	if got.Domain != "new.com" {
+		t.Errorf("Domain = %q, want %q", got.Domain, "new.com")
+	}
+}
+
+// ---- BotSession -------------------------------------------------------------
+
+func TestBotSession_CreateAndPurge(t *testing.T) {
+	initTestDB(t)
+	now := time.Now()
+
+	// Active session (expires in the future)
+	_ = CreateBotSession(&BotSession{
+		ID:        "sess-active",
+		TunnelID:  "t1",
+		IP:        "1.2.3.4",
+		IssuedAt:  now,
+		ExpiresAt: now.Add(time.Hour),
+	})
+	// Expired session
+	_ = CreateBotSession(&BotSession{
+		ID:        "sess-expired",
+		TunnelID:  "t1",
+		IP:        "1.2.3.5",
+		IssuedAt:  now.Add(-2 * time.Hour),
+		ExpiresAt: now.Add(-1 * time.Hour),
+	})
+
+	if err := PurgeBotSessions(); err != nil {
+		t.Fatalf("PurgeBotSessions: %v", err)
+	}
+
+	var count int64
+	DB.Model(&BotSession{}).Count(&count)
+	if count != 1 {
+		t.Errorf("after purge: count = %d, want 1 (active session only)", count)
+	}
+}
+
+// ---- Bootstrap token --------------------------------------------------------
+
+func TestBootstrapToken_CreateAndGet(t *testing.T) {
+	initTestDB(t)
+	exp := time.Now().Add(time.Hour)
+	bt := &BootstrapToken{
+		ID:        "bt1",
+		Token:     "secret-token",
+		ExpiresAt: exp,
+	}
+	if err := CreateBootstrapToken(bt); err != nil {
+		t.Fatalf("CreateBootstrapToken: %v", err)
+	}
+	got, err := GetBootstrapToken("secret-token")
+	if err != nil {
+		t.Fatalf("GetBootstrapToken: %v", err)
+	}
+	if got.ID != "bt1" {
+		t.Errorf("ID = %q, want %q", got.ID, "bt1")
+	}
+}
+
+func TestBootstrapToken_NotFound(t *testing.T) {
+	initTestDB(t)
+	_, err := GetBootstrapToken("nope")
+	if err == nil {
+		t.Fatal("expected error for missing token, got nil")
+	}
+}
+
+func TestBootstrapToken_MarkUsed(t *testing.T) {
+	initTestDB(t)
+	_ = CreateBootstrapToken(&BootstrapToken{
+		ID:        "bt1",
+		Token:     "tok",
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+	machineID := "m1"
+	if err := MarkTokenUsed("bt1", machineID); err != nil {
+		t.Fatalf("MarkTokenUsed: %v", err)
+	}
+	got, _ := GetBootstrapToken("tok")
+	if got.MachineID == nil || *got.MachineID != machineID {
+		t.Errorf("MachineID = %v, want %q", got.MachineID, machineID)
+	}
+	if got.UsedAt == nil {
+		t.Error("UsedAt should be set after marking used")
+	}
+}
+
+// ---- GetTunnelBySubdomain ---------------------------------------------------
+
+func TestGetTunnelBySubdomain(t *testing.T) {
+	initTestDB(t)
+	seedMachine(t, "m1")
+	_ = CreateTunnel(&Tunnel{ID: "t1", MachineID: "m1", Subdomain: "api", RatholePort: 8000})
+
+	got, err := GetTunnelBySubdomain("api")
+	if err != nil {
+		t.Fatalf("GetTunnelBySubdomain: %v", err)
+	}
+	if got.ID != "t1" {
+		t.Errorf("ID = %q, want %q", got.ID, "t1")
+	}
+
+	_, err = GetTunnelBySubdomain("missing")
+	if err == nil {
+		t.Fatal("expected error for missing subdomain, got nil")
+	}
+}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -412,7 +412,7 @@ func extractPort(t *testing.T, rawURL string) int {
 		t.Fatalf("parse url %q: %v", rawURL, err)
 	}
 	var port int
-	fmt.Sscanf(u.Port(), "%d", &port)
+	_, _ = fmt.Sscanf(u.Port(), "%d", &port)
 	return port
 }
 

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -363,8 +363,3 @@ func generateToken() (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
-// logAuthEvent is kept for external callers (e.g. bootstrap) that don't have
-// an AuthService reference.
-func logAuthEvent(event, ip string) {
-	log.Printf("gopher-auth: %s ip=%s", event, ip)
-}

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -1,0 +1,289 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---- auditRing --------------------------------------------------------------
+
+func TestAuditRing_AddAndSnapshot(t *testing.T) {
+	var ring auditRing
+	ring.add("LOGIN_SUCCESS", "1.2.3.4")
+	ring.add("LOGIN_FAILED", "5.6.7.8")
+
+	snap := ring.Snapshot()
+	if len(snap) != 2 {
+		t.Fatalf("len = %d, want 2", len(snap))
+	}
+	// Snapshot is newest-first
+	if snap[0].Event != "LOGIN_FAILED" {
+		t.Errorf("newest event = %q, want LOGIN_FAILED", snap[0].Event)
+	}
+	if snap[1].Event != "LOGIN_SUCCESS" {
+		t.Errorf("second event = %q, want LOGIN_SUCCESS", snap[1].Event)
+	}
+}
+
+func TestAuditRing_WrapsAtCapacity(t *testing.T) {
+	var ring auditRing
+	for i := 0; i < auditLogCapacity+10; i++ {
+		ring.add(fmt.Sprintf("event-%d", i), "1.2.3.4")
+	}
+	snap := ring.Snapshot()
+	if len(snap) != auditLogCapacity {
+		t.Errorf("len = %d, want %d (capacity)", len(snap), auditLogCapacity)
+	}
+	// Newest event should be the last one written
+	want := fmt.Sprintf("event-%d", auditLogCapacity+9)
+	if snap[0].Event != want {
+		t.Errorf("newest = %q, want %q", snap[0].Event, want)
+	}
+}
+
+func TestAuditRing_EmptySnapshot(t *testing.T) {
+	var ring auditRing
+	snap := ring.Snapshot()
+	if len(snap) != 0 {
+		t.Errorf("expected empty snapshot, got %d events", len(snap))
+	}
+}
+
+// ---- AuthService: Setup and Login -------------------------------------------
+
+func TestAuthService_SetupAndLogin(t *testing.T) {
+	initTestDB(t)
+	svc := NewAuthService()
+
+	setup, _ := svc.IsSetup()
+	if setup {
+		t.Fatal("should not be set up on fresh DB")
+	}
+
+	if err := svc.Setup("correctpassword"); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+
+	setup, _ = svc.IsSetup()
+	if !setup {
+		t.Fatal("should be set up after Setup()")
+	}
+
+	result, err := svc.Login("correctpassword", "127.0.0.1")
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if result.Token == "" {
+		t.Error("expected non-empty session token")
+	}
+	if result.NeedsTOTP {
+		t.Error("should not need TOTP when not enrolled")
+	}
+}
+
+func TestAuthService_SetupRejectsShortPassword(t *testing.T) {
+	initTestDB(t)
+	svc := NewAuthService()
+	if err := svc.Setup("short"); err == nil {
+		t.Error("expected error for password < 8 chars")
+	}
+}
+
+func TestAuthService_SetupIdempotentRejection(t *testing.T) {
+	initTestDB(t)
+	svc := NewAuthService()
+	_ = svc.Setup("firstpassword")
+	if err := svc.Setup("secondpassword"); err == nil {
+		t.Error("expected error when Setup called twice")
+	}
+}
+
+func TestAuthService_LoginWrongPassword(t *testing.T) {
+	initTestDB(t)
+	svc := NewAuthService()
+	_ = svc.Setup("correctpassword")
+
+	_, err := svc.Login("wrongpassword", "127.0.0.1")
+	if err == nil {
+		t.Error("expected error for wrong password")
+	}
+}
+
+func TestAuthService_LoginBeforeSetup(t *testing.T) {
+	initTestDB(t)
+	svc := NewAuthService()
+	_, err := svc.Login("anypassword", "127.0.0.1")
+	if err == nil {
+		t.Error("expected error when logging in before setup")
+	}
+}
+
+// ---- Session management -----------------------------------------------------
+
+func TestAuthService_ValidateSession(t *testing.T) {
+	initTestDB(t)
+	svc := NewAuthService()
+	_ = svc.Setup("password123")
+
+	result, _ := svc.Login("password123", "127.0.0.1")
+	token := result.Token
+
+	if !svc.ValidateSession(token) {
+		t.Error("fresh session should be valid")
+	}
+}
+
+func TestAuthService_ValidateSession_InvalidToken(t *testing.T) {
+	initTestDB(t)
+	svc := NewAuthService()
+	if svc.ValidateSession("not-a-real-token") {
+		t.Error("random token should be invalid")
+	}
+	if svc.ValidateSession("") {
+		t.Error("empty token should be invalid")
+	}
+}
+
+func TestAuthService_Logout(t *testing.T) {
+	initTestDB(t)
+	svc := NewAuthService()
+	_ = svc.Setup("password123")
+
+	result, _ := svc.Login("password123", "127.0.0.1")
+	token := result.Token
+
+	svc.Logout(token)
+	if svc.ValidateSession(token) {
+		t.Error("token should be invalid after logout")
+	}
+}
+
+func TestAuthService_LogoutNonexistentToken(t *testing.T) {
+	initTestDB(t)
+	svc := NewAuthService()
+	// Should not panic
+	svc.Logout("non-existent-token")
+}
+
+// ---- Rate limiter -----------------------------------------------------------
+
+func TestLoginRateLimiter_AllowsUnderLimit(t *testing.T) {
+	rl := newLoginRateLimiter()
+	for i := 0; i < loginRateLimit; i++ {
+		if !rl.record("1.2.3.4") {
+			t.Errorf("attempt %d should be allowed", i+1)
+		}
+	}
+}
+
+func TestLoginRateLimiter_BlocksAtLimit(t *testing.T) {
+	rl := newLoginRateLimiter()
+	for i := 0; i < loginRateLimit; i++ {
+		rl.record("1.2.3.4")
+	}
+	if rl.record("1.2.3.4") {
+		t.Error("attempt beyond limit should be blocked")
+	}
+}
+
+func TestLoginRateLimiter_IsolatesIPs(t *testing.T) {
+	rl := newLoginRateLimiter()
+	for i := 0; i < loginRateLimit; i++ {
+		rl.record("1.2.3.4")
+	}
+	// Different IP should still be allowed
+	if !rl.record("5.6.7.8") {
+		t.Error("different IP should not be rate limited")
+	}
+}
+
+func TestLoginRateLimiter_ResetClearsAttempts(t *testing.T) {
+	rl := newLoginRateLimiter()
+	for i := 0; i < loginRateLimit; i++ {
+		rl.record("1.2.3.4")
+	}
+	rl.Reset("1.2.3.4")
+	if !rl.record("1.2.3.4") {
+		t.Error("after reset, IP should be allowed again")
+	}
+}
+
+// ---- ClientIP ---------------------------------------------------------------
+
+func TestClientIP_FromRemoteAddr(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "192.168.1.1:12345"
+	if got := ClientIP(r); got != "192.168.1.1" {
+		t.Errorf("ClientIP = %q, want %q", got, "192.168.1.1")
+	}
+}
+
+func TestClientIP_XForwardedFor(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Forwarded-For", "10.0.0.1, 10.0.0.2")
+	r.RemoteAddr = "127.0.0.1:9999"
+	if got := ClientIP(r); got != "10.0.0.1" {
+		t.Errorf("ClientIP = %q, want %q (first XFF entry)", got, "10.0.0.1")
+	}
+}
+
+func TestClientIP_XForwardedForSingle(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Forwarded-For", "203.0.113.5")
+	if got := ClientIP(r); got != "203.0.113.5" {
+		t.Errorf("ClientIP = %q, want %q", got, "203.0.113.5")
+	}
+}
+
+// ---- AuditLog via AuthService -----------------------------------------------
+
+func TestAuthService_AuditLogRecordsEvents(t *testing.T) {
+	initTestDB(t)
+	svc := NewAuthService()
+	_ = svc.Setup("password123")
+
+	_, _ = svc.Login("wrongpassword", "10.0.0.1")
+	_, _ = svc.Login("password123", "10.0.0.2")
+
+	log := svc.AuditLog()
+	if len(log) < 2 {
+		t.Fatalf("expected at least 2 audit events, got %d", len(log))
+	}
+
+	events := make([]string, len(log))
+	for i, e := range log {
+		events[i] = e.Event
+	}
+	joined := strings.Join(events, ",")
+
+	if !strings.Contains(joined, "LOGIN_FAILED") {
+		t.Error("expected LOGIN_FAILED event in audit log")
+	}
+	if !strings.Contains(joined, "LOGIN_SUCCESS") {
+		t.Error("expected LOGIN_SUCCESS event in audit log")
+	}
+}
+
+// ---- Audit event timing -----------------------------------------------------
+
+func TestAuditRing_EventHasTimestamp(t *testing.T) {
+	var ring auditRing
+	before := time.Now()
+	ring.add("TEST_EVENT", "1.2.3.4")
+	after := time.Now()
+
+	snap := ring.Snapshot()
+	if len(snap) == 0 {
+		t.Fatal("expected 1 event")
+	}
+	if snap[0].Time.Before(before) || snap[0].Time.After(after) {
+		t.Errorf("event timestamp %v not in expected range [%v, %v]", snap[0].Time, before, after)
+	}
+	if snap[0].IP != "1.2.3.4" {
+		t.Errorf("IP = %q, want %q", snap[0].IP, "1.2.3.4")
+	}
+}

--- a/internal/service/firewall_manage.go
+++ b/internal/service/firewall_manage.go
@@ -489,11 +489,3 @@ func persistRules() {
 		_ = writeLocalFile(savePath, string(out))
 	}
 }
-
-// iptablesMakePublic makes a private port publicly reachable again.
-func iptablesMakePublic(port int, proto string) error {
-	portStr := strconv.Itoa(port)
-	iptablesDeleteRule(gopherChain, "-p", proto, "--dport", portStr, "-s", "127.0.0.1", "-j", "ACCEPT")
-	iptablesDeleteRule(gopherChain, "-p", proto, "--dport", portStr, "-j", "DROP")
-	return iptablesOpenPort(port, proto)
-}

--- a/internal/service/local_status.go
+++ b/internal/service/local_status.go
@@ -210,8 +210,8 @@ func addToAuthorizedKeys(pubKey string) error {
 		if err2 := exec.Command("sudo", "mkdir", "-p", sshDir).Run(); err2 != nil { // #nosec G204
 			return fmt.Errorf("mkdir %s: %w", sshDir, err2)
 		}
-		exec.Command("sudo", "chmod", "700", sshDir).Run()                              // #nosec G204
-		exec.Command("sudo", "chown", u.Username+":"+u.Username, sshDir).Run()          // #nosec G204
+		_ = exec.Command("sudo", "chmod", "700", sshDir).Run()                              // #nosec G204
+		_ = exec.Command("sudo", "chown", u.Username+":"+u.Username, sshDir).Run()          // #nosec G204
 	}
 
 	// Read existing content.
@@ -248,8 +248,8 @@ func addToAuthorizedKeys(pubKey string) error {
 		if err2 := cmd.Run(); err2 != nil {
 			return err2
 		}
-		exec.Command("sudo", "chmod", "600", path).Run()                             // #nosec G204
-		exec.Command("sudo", "chown", u.Username+":"+u.Username, path).Run()         // #nosec G204
+		_ = exec.Command("sudo", "chmod", "600", path).Run()                             // #nosec G204
+		_ = exec.Command("sudo", "chown", u.Username+":"+u.Username, path).Run()         // #nosec G204
 	}
 	return nil
 }
@@ -300,8 +300,8 @@ func removeFromAuthorizedKeys(pubKey string) error {
 		if err2 := cmd.Run(); err2 != nil {
 			return err2
 		}
-		exec.Command("sudo", "chmod", "600", path).Run()                             // #nosec G204
-		exec.Command("sudo", "chown", u.Username+":"+u.Username, path).Run()         // #nosec G204
+		_ = exec.Command("sudo", "chmod", "600", path).Run()                             // #nosec G204
+		_ = exec.Command("sudo", "chown", u.Username+":"+u.Username, path).Run()         // #nosec G204
 	}
 	return nil
 }

--- a/internal/service/machine.go
+++ b/internal/service/machine.go
@@ -120,7 +120,7 @@ func (s *MachineService) Deploy(id string) error {
 		return err
 	}
 
-	go s.deploy.DeployClient(machine)
+	go s.deploy.DeployClient(machine) //nolint:errcheck
 	return nil
 }
 

--- a/internal/service/update_test.go
+++ b/internal/service/update_test.go
@@ -1,0 +1,211 @@
+package service
+
+import (
+	"testing"
+)
+
+func TestInferChannelFromVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		want    string
+	}{
+		{"v0.1.0", "stable"},
+		{"v1.2.3", "stable"},
+		{"0.1.0", "stable"},
+		{"v0.1.0-alpha.1", "alpha"},
+		{"v0.1.0-alpha.8", "alpha"},
+		{"v0.1.0-beta.1", "beta"},
+		{"v0.1.0-beta.3", "beta"},
+		{"v0.1.0-rc.1", "alpha"},  // unknown pre-release → alpha (most permissive)
+		{"V0.1.0-ALPHA.1", "alpha"}, // case-insensitive
+		{"dev", "stable"},          // no dash → stable
+		{"", "stable"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			got := inferChannelFromVersion(tt.version)
+			if got != tt.want {
+				t.Errorf("inferChannelFromVersion(%q) = %q, want %q", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSemver(t *testing.T) {
+	tests := []struct {
+		tag  string
+		want *semverParts
+	}{
+		{"v1.2.3", &semverParts{1, 2, 3, ""}},
+		{"1.2.3", &semverParts{1, 2, 3, ""}},
+		{"v0.1.0-alpha.5", &semverParts{0, 1, 0, "alpha.5"}},
+		{"v0.1.0-beta.2", &semverParts{0, 1, 0, "beta.2"}},
+		{"v0.1.0-alpha-5", &semverParts{0, 1, 0, "alpha.5"}}, // dash → dot normalization
+		{"invalid", nil},
+		{"1.2", nil},        // missing patch
+		{"1.2.x", nil},     // non-numeric patch
+		{"", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			got := parseSemver(tt.tag)
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("parseSemver(%q) = %+v, want nil", tt.tag, got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("parseSemver(%q) = nil, want %+v", tt.tag, tt.want)
+			}
+			if *got != *tt.want {
+				t.Errorf("parseSemver(%q) = %+v, want %+v", tt.tag, *got, *tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareSemver(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		// major/minor/patch ordering
+		{"v1.0.0", "v0.9.9", 1},
+		{"v0.9.9", "v1.0.0", -1},
+		{"v0.2.0", "v0.1.9", 1},
+		{"v0.1.9", "v0.2.0", -1},
+		{"v0.1.1", "v0.1.0", 1},
+		{"v0.1.0", "v0.1.1", -1},
+		{"v1.2.3", "v1.2.3", 0},
+		// stable > prerelease for equal X.Y.Z
+		{"v0.1.0", "v0.1.0-alpha.1", 1},
+		{"v0.1.0-alpha.1", "v0.1.0", -1},
+		// prerelease ordering
+		{"v0.1.0-beta.1", "v0.1.0-alpha.5", 1},
+		{"v0.1.0-alpha.5", "v0.1.0-beta.1", -1},
+		{"v0.1.0-alpha.2", "v0.1.0-alpha.1", 1},
+		{"v0.1.0-alpha.1", "v0.1.0-alpha.2", -1},
+		{"v0.1.0-alpha.1", "v0.1.0-alpha.1", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.a+"_vs_"+tt.b, func(t *testing.T) {
+			a := parseSemver(tt.a)
+			b := parseSemver(tt.b)
+			if a == nil || b == nil {
+				t.Fatalf("parseSemver failed for inputs")
+			}
+			got := compareSemver(*a, *b)
+			if got != tt.want {
+				t.Errorf("compareSemver(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsNewer(t *testing.T) {
+	tests := []struct {
+		latest, current string
+		want            bool
+	}{
+		{"v0.1.1", "v0.1.0", true},
+		{"v0.1.0", "v0.1.1", false},
+		{"v0.1.0", "v0.1.0", false},
+		{"v0.2.0", "v0.1.9", true},
+		{"v1.0.0", "v0.9.9", true},
+		// stable is newer than same-version prerelease
+		{"v0.1.0", "v0.1.0-alpha.5", true},
+		{"v0.1.0-alpha.5", "v0.1.0", false},
+		// beta is newer than alpha of same version
+		{"v0.1.0-beta.1", "v0.1.0-alpha.8", true},
+		{"v0.1.0-alpha.8", "v0.1.0-beta.1", false},
+		// alpha increments
+		{"v0.1.0-alpha.2", "v0.1.0-alpha.1", true},
+		{"v0.1.0-alpha.1", "v0.1.0-alpha.2", false},
+		// invalid tags fall back to string inequality
+		{"invalid-new", "invalid-old", true},
+		{"same", "same", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.latest+"_vs_"+tt.current, func(t *testing.T) {
+			got := isNewer(tt.latest, tt.current)
+			if got != tt.want {
+				t.Errorf("isNewer(%q, %q) = %v, want %v", tt.latest, tt.current, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReleaseMatchesChannel(t *testing.T) {
+	makeRelease := func(tag string, prerelease, draft bool) *githubRelease {
+		return &githubRelease{TagName: tag, Prerelease: prerelease, Draft: draft}
+	}
+
+	tests := []struct {
+		name    string
+		release *githubRelease
+		channel string
+		want    bool
+	}{
+		// drafts always excluded
+		{"draft excluded", makeRelease("v1.0.0", false, true), "alpha", false},
+		{"draft excluded stable", makeRelease("v1.0.0", false, true), "stable", false},
+		// empty tag excluded
+		{"empty tag", makeRelease("", false, false), "alpha", false},
+		// stable channel: only stable releases
+		{"stable on stable", makeRelease("v1.0.0", false, false), "stable", true},
+		{"alpha on stable", makeRelease("v0.1.0-alpha.1", true, false), "stable", false},
+		{"beta on stable", makeRelease("v0.1.0-beta.1", true, false), "stable", false},
+		// beta channel: stable + beta, no alpha
+		{"stable on beta", makeRelease("v1.0.0", false, false), "beta", true},
+		{"beta on beta", makeRelease("v0.1.0-beta.1", true, false), "beta", true},
+		{"alpha on beta", makeRelease("v0.1.0-alpha.1", true, false), "beta", false},
+		// alpha channel: everything non-draft
+		{"stable on alpha", makeRelease("v1.0.0", false, false), "alpha", true},
+		{"beta on alpha", makeRelease("v0.1.0-beta.1", true, false), "alpha", true},
+		{"alpha on alpha", makeRelease("v0.1.0-alpha.5", true, false), "alpha", true},
+		// invalid semver tag excluded
+		{"invalid tag", makeRelease("nightly-20240101", false, false), "alpha", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := releaseMatchesChannel(tt.release, tt.channel)
+			if got != tt.want {
+				t.Errorf("releaseMatchesChannel(%q, %q) = %v, want %v", tt.release.TagName, tt.channel, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComparePrerelease(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"alpha.1", "alpha.1", 0},
+		{"alpha.2", "alpha.1", 1},
+		{"alpha.1", "alpha.2", -1},
+		{"beta.1", "alpha.5", 1},  // "beta" > "alpha" lexicographically
+		{"alpha.5", "beta.1", -1},
+		// numeric identifiers compare numerically not lexicographically
+		{"alpha.10", "alpha.9", 1},
+		{"alpha.9", "alpha.10", -1},
+		// more identifiers = newer (semver spec)
+		{"alpha.1.1", "alpha.1", 1},
+		{"alpha.1", "alpha.1.1", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.a+"_vs_"+tt.b, func(t *testing.T) {
+			got := comparePrerelease(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("comparePrerelease(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/service/vps.go
+++ b/internal/service/vps.go
@@ -85,7 +85,7 @@ func (s *VPSService) Bootstrap() error {
 	if err != nil {
 		return err
 	}
-	go s.deploy.Bootstrap(vps)
+	go s.deploy.Bootstrap(vps) //nolint:errcheck
 	return nil
 }
 
@@ -94,7 +94,7 @@ func (s *VPSService) Deploy() error {
 	if err != nil {
 		return err
 	}
-	go s.deploy.DeployVPS(vps)
+	go s.deploy.DeployVPS(vps) //nolint:errcheck
 	return nil
 }
 

--- a/tests/unit/config_test.go
+++ b/tests/unit/config_test.go
@@ -389,15 +389,13 @@ bind_addr = "0.0.0.0:25000"
 # gopher-tunnel-end: my-tunnel
 `
 
-	result := config.ValidateRatholeConfig(cfg, []db.Machine{}, []db.Tunnel{})
-
 	// If validation checks can access parsed config directly, verify token/bind_addr were extracted
 	// For now, we validate a machine with the same ID and token should pass
 	tunnels := []db.Tunnel{
 		{ID: "my-tunnel", RatholePort: 25000, RatholeToken: "secret-token-123", CreatedAt: time.Now(), UpdatedAt: time.Now()},
 	}
 
-	result = config.ValidateRatholeConfig(cfg, []db.Machine{}, tunnels)
+	result := config.ValidateRatholeConfig(cfg, []db.Machine{}, tunnels)
 
 	if !result.Valid {
 		t.Errorf("Should correctly extract token and bind_addr. Errors: %v", result.Errors)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Resolves #62 
Contributes to #60 

## Changes Made
<!-- List the main changes -->
- Added unit tests for internal/config: config generation (GenerateRatholeServerConfig, GenerateMachineSSHClientConfig, GenerateClientConfig), parser (markers, duplicates, unclosed/mismatched markers), validator (ValidateSubdomain, ValidatePort, ValidateRatholeConfig), and a generate→validate roundtrip
- Added unit tests for internal/db: machine/tunnel CRUD, NextRatholePort/NextSSHTunnelPort gap-finding, cross-table port conflict checks, subdomain conflict checks, AppSettings save/reload, BotSession purge, bootstrap token lifecycle
- Added unit tests for internal/service: semver parsing and comparison (parseSemver, compareSemver, comparePrerelease, isNewer), update channel inference (inferChannelFromVersion, releaseMatchesChannel), auth service (setup, login, logout, session validation), audit ring (add, snapshot, wrap at capacity), rate limiter (allow/block/isolate/reset), ClientIP extraction
- Added security tests for internal/api: all protected routes return 401 without auth, public routes stay accessible, invalid tokens rejected, authenticated access works, CORS preflight and headers, 401 responses are JSON, logout invalidates session
- Added performance benchmarks for config generation (10/100/200 entries), rathole config parsing, subdomain lookups, and port assignment under load
- Removed dead code: extractPortFromAddr (config), logAuthEvent (auth), iptablesMakePublic (firewall)
- Fixed all golangci-lint issues (unchecked error returns, unused imports)

## Testing
<!-- Describe how you tested these changes -->
- [ ] Tested locally
- [x] Added/updated unit tests
- [x] All tests passing

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->



