### PR TITLE
fix: jumpbox authorized_keys must include port-forwarding to actually…

### DIFF
--- a/internal/service/authorized_keys_test.go
+++ b/internal/service/authorized_keys_test.go
@@ -1,6 +1,9 @@
 package service
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // keydataTokenFromLine handles four authorized_keys line shapes:
 //   1. Plain: "ssh-ed25519 AAAA... comment"
@@ -87,8 +90,28 @@ func TestAuthorizedKeysLine_NoOptions(t *testing.T) {
 
 func TestAuthorizedKeysLine_WithOptions(t *testing.T) {
 	got := authorizedKeysLine("ssh-ed25519 AAAA gopher", jumpboxKeyOptions)
-	want := `restrict,permitopen="127.0.0.1:*",permitopen="localhost:*" ssh-ed25519 AAAA gopher`
+	want := `restrict,port-forwarding,permitopen="127.0.0.1:*",permitopen="localhost:*" ssh-ed25519 AAAA gopher`
 	if got != want {
 		t.Errorf("line = %q, want %q", got, want)
+	}
+}
+
+// TestJumpboxKeyOptions_HasPortForwardingReEnable guards against a future
+// refactor that drops `port-forwarding` from the options string.
+//
+// `restrict` alone disables port forwarding — the permitopen filter list
+// is consulted only AFTER permit_port_forwarding_flag is enabled. Without
+// `port-forwarding`, sshd denies the channel-open with "administratively
+// prohibited" even though authentication succeeds, which broke every
+// operator's `ssh -J gopher-jump@vps -p <rathole_port> ...` flow.
+//
+// The order matters too: `port-forwarding` must come AFTER `restrict`
+// (left-to-right evaluation; later options override earlier ones).
+func TestJumpboxKeyOptions_HasPortForwardingReEnable(t *testing.T) {
+	if !strings.HasPrefix(jumpboxKeyOptions, "restrict,port-forwarding,") {
+		t.Fatalf(
+			"jumpboxKeyOptions must start with `restrict,port-forwarding,` to "+
+				"actually permit jumpbox forwarding; got %q", jumpboxKeyOptions,
+		)
 	}
 }

--- a/internal/service/local_status.go
+++ b/internal/service/local_status.go
@@ -213,10 +213,25 @@ const jumpboxUsername = "gopher-jump"
 // jumpboxKeyOptions wraps each authorized_keys line with OpenSSH options
 // that lock the key to TCP-forwarding into local ports — exactly what the
 // jumpbox flow needs (`ssh -J gopher-jump@vps -p <rathole_port> ...`) and
-// nothing else. `restrict` disables shell, X11, agent forwarding, env,
-// and `~/.ssh/rc`. `permitopen=127.0.0.1:*` and `permitopen=localhost:*`
-// whitelist the only legitimate forward target — the rathole binds.
-const jumpboxKeyOptions = `restrict,permitopen="127.0.0.1:*",permitopen="localhost:*"`
+// nothing else.
+//
+// Layered semantics:
+//   - `restrict` disables shell, X11, agent forwarding, env, ~/.ssh/rc,
+//     PTY, AND port forwarding. It's the safe-by-default base.
+//   - `port-forwarding` re-enables port forwarding specifically. This
+//     IS required: `restrict,permitopen=...` alone leaves
+//     permit_port_forwarding_flag at 0 and sshd denies the channel
+//     before consulting the permitopen list (auth-options.c). The
+//     symptom is "channel 0: open failed: administratively prohibited"
+//     even though sshd accepts the publickey.
+//   - `permitopen="127.0.0.1:*"` / `permitopen="localhost:*"` narrow
+//     the now-enabled port forwarding down to localhost-only targets,
+//     i.e. the rathole bind addresses operators legitimately reach via
+//     the jumpbox flow.
+//
+// Net result: shell off, agent forwarding off, X11 off — but jumpbox
+// forwards to localhost ports work.
+const jumpboxKeyOptions = `restrict,port-forwarding,permitopen="127.0.0.1:*",permitopen="localhost:*"`
 
 // jumpboxUserExists reports whether the dedicated jumpbox user is set up.
 // During upgrades from pre-v0.1.0 deployments this returns false until the


### PR DESCRIPTION
… forward

The previous options string was

  restrict,permitopen="127.0.0.1:*",permitopen="localhost:*"

which authenticates fine but blocks every channel-open request:

  channel 0: open failed: administratively prohibited
  stdio forwarding failed
  Connection closed by UNKNOWN port 65535

Reason: OpenSSH's `restrict` sets permit_port_forwarding_flag = 0, and `permitopen` only adds entries to a filter list — it does not flip the flag back on. The channel-open hook checks the flag BEFORE consulting permitopen, so the restriction wins and the permitopen entries are dead config. The man page hints at this: "may be followed by other options (e.g., port-forwarding) that re-enable specific functionality."

`port-forwarding` is the explicit re-enable; `permitopen` is the narrower filter that applies once forwarding is enabled. Adding it between `restrict` and the permitopens fixes the operator's `ssh -J gopher-jump@vps -p <rathole_port> ...` flow without loosening any of the other restrict-imposed protections (no shell, no X11, no agent, no env, no ~/.ssh/rc, no PTY).

The next ReconcileAuthorizedKeys cycle after this ships rewrites every existing options line in place — addToAuthorizedKeysFor matches by type+keydata token, ignoring options, so updating the prefix doesn't duplicate or scrub the keys. Operators who already migrated to the new authorized_keys layout get the fix on the next service start.

Regression test guards against a future refactor that drops `port-forwarding` from the options string.

## Description
<!-- Provide a brief description of the changes in this PR -->
Resolves #__

## Changes Made
<!-- List the main changes -->
- 
- 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Tested locally
- [ ] Added/updated unit tests
- [ ] All tests passing

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->



