### PR TITLE
test: bump server-ready timeout from 15s to 30s in shell integration …

### DIFF
--- a/tests/config-validation.sh
+++ b/tests/config-validation.sh
@@ -45,13 +45,15 @@ echo "1. Starting Gopher on port $GOPHER_PORT..."
 ./gopher --db "$GOPHER_DB" --port "$GOPHER_PORT" >/dev/null 2>&1 &
 GOPHER_PID=$!
 
-for i in $(seq 1 30); do
+# 30s ceiling — CI runners hit the previous 15s cap intermittently
+# under cold-cache conditions; see critical-path.sh for the same fix.
+for i in $(seq 1 60); do
     if curl -sf "http://localhost:$GOPHER_PORT/api/status" >/dev/null 2>&1; then
         pass "Server ready"
         break
     fi
     sleep 0.5
-    [[ $i -eq 30 ]] && fail "Server did not start within 15 seconds"
+    [[ $i -eq 60 ]] && fail "Server did not start within 30 seconds"
 done
 
 # ── Auth ───────────────────────────────────────────────────────────────────────

--- a/tests/critical-path.sh
+++ b/tests/critical-path.sh
@@ -43,15 +43,18 @@ echo "1. Starting Gopher on port $GOPHER_PORT..."
 ./gopher --db "$GOPHER_DB" --port "$GOPHER_PORT" >/dev/null 2>&1 &
 GOPHER_PID=$!
 
-# Poll until ready (up to 15s)
-for i in $(seq 1 30); do
+# Poll until ready (up to 30s). 15s was tight enough that local laptops
+# passed at ~13s but GitHub Actions runners (slower disks + cold caches)
+# regularly tripped the ceiling — bumped to 30s so the test reflects
+# actual server-up latency, not the runner's I/O variance.
+for i in $(seq 1 60); do
     if curl -sf "http://localhost:$GOPHER_PORT/api/status" >/dev/null 2>&1; then
         pass "Server ready (${i} × 0.5s)"
         break
     fi
     sleep 0.5
-    if [[ $i -eq 30 ]]; then
-        fail "Server did not start within 15 seconds"
+    if [[ $i -eq 60 ]]; then
+        fail "Server did not start within 30 seconds"
     fi
 done
 

--- a/tests/idempotency.sh
+++ b/tests/idempotency.sh
@@ -43,13 +43,15 @@ echo "1. Starting Gopher on port $GOPHER_PORT..."
 ./gopher --db "$GOPHER_DB" --port "$GOPHER_PORT" >/dev/null 2>&1 &
 GOPHER_PID=$!
 
-for i in $(seq 1 30); do
+# 30s ceiling — CI runners hit the previous 15s cap intermittently
+# under cold-cache conditions; see critical-path.sh for the same fix.
+for i in $(seq 1 60); do
     if curl -sf "http://localhost:$GOPHER_PORT/api/status" >/dev/null 2>&1; then
         pass "Server ready"
         break
     fi
     sleep 0.5
-    [[ $i -eq 30 ]] && fail "Server did not start within 15 seconds"
+    [[ $i -eq 60 ]] && fail "Server did not start within 30 seconds"
 done
 
 # ── Auth ───────────────────────────────────────────────────────────────────────

--- a/tests/state-reconciliation.sh
+++ b/tests/state-reconciliation.sh
@@ -43,13 +43,15 @@ echo "1. Starting Gopher on port $GOPHER_PORT..."
 ./gopher --db "$GOPHER_DB" --port "$GOPHER_PORT" >/dev/null 2>&1 &
 GOPHER_PID=$!
 
-for i in $(seq 1 30); do
+# 30s ceiling — CI runners hit the previous 15s cap intermittently
+# under cold-cache conditions; see critical-path.sh for the same fix.
+for i in $(seq 1 60); do
     if curl -sf "http://localhost:$GOPHER_PORT/api/status" >/dev/null 2>&1; then
         pass "Server ready"
         break
     fi
     sleep 0.5
-    [[ $i -eq 30 ]] && fail "Server did not start within 15 seconds"
+    [[ $i -eq 60 ]] && fail "Server did not start within 30 seconds"
 done
 
 # ── Auth ───────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
…tests

Local runs were hitting ~13s on the 15s cap, leaving zero headroom for GitHub Actions runners (slower disks + cold caches). Bumped every shell test's startup poll loop to 60 × 0.5s = 30s. Same change applied identically across critical-path, config-validation, state-reconciliation, and idempotency so the four tests stay calibrated together.

## Description
<!-- Provide a brief description of the changes in this PR -->
Resolves #__

## Changes Made
<!-- List the main changes -->
- 
- 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Tested locally
- [ ] Added/updated unit tests
- [ ] All tests passing

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->



